### PR TITLE
Added a line to remove stale (not accessed in a week) values from the cache

### DIFF
--- a/tests/functional/simple_test.py
+++ b/tests/functional/simple_test.py
@@ -485,10 +485,9 @@ def test_remove_stale_cache_values(tmpdir):
     today_time = int(time.time())
     this_week_time = int(time.time()) - seconds_in_day*3
     last_month_time = int(time.time()) - seconds_in_day*40
-    epoch_time = 0
 
     # Sets the access times of stale package/wheel to be older than a week.
-    os.utime(stale_cached_package, (epoch_time, epoch_time))  # Jan 1, 1970
+    os.utime(stale_cached_package, (0, 0))  # Jan 1, 1970
     os.utime(stale_cached_wheel, (last_month_time, last_month_time))
 
     # Sets the access times of fresh package/wheel to be within the past week.
@@ -500,10 +499,10 @@ def test_remove_stale_cache_values(tmpdir):
 
     # Assert that we can no longer access the stale package/wheel
     # because tmpwatch has removed them.
-    assert os.access(stale_cached_package, os.F_OK) == False
-    assert os.access(stale_cached_wheel, os.F_OK) == False
+    assert not os.access(stale_cached_package, os.F_OK)
+    assert not os.access(stale_cached_wheel, os.F_OK)
 
     # Assert that we can still access the fresh package/wheel,
     # tmpwatch should not have removed them.
-    assert os.access(fresh_cached_package, os.F_OK) == True
-    assert os.access(fresh_cached_wheel, os.F_OK) == True
+    assert os.access(fresh_cached_package, os.F_OK)
+    assert os.access(fresh_cached_wheel, os.F_OK)

--- a/tests/functional/simple_test.py
+++ b/tests/functional/simple_test.py
@@ -499,11 +499,11 @@ def test_remove_stale_cache_values(tmpdir):
     venv_update()
 
     # Assert that we can no longer access the stale package/wheel
-    # because tmpwatch has removed them.
+    # that have been removed.
     assert not os.access(stale_cached_package, os.F_OK)
     assert not os.access(stale_cached_wheel, os.F_OK)
 
     # Assert that we can still access the fresh package/wheel,
-    # tmpwatch should not have removed them.
+    # they should not have been removed.
     assert os.access(fresh_cached_package, os.F_OK)
     assert os.access(fresh_cached_wheel, os.F_OK)

--- a/tests/functional/simple_test.py
+++ b/tests/functional/simple_test.py
@@ -451,3 +451,59 @@ def test_downgrade(tmpdir):
     tmpdir.chdir()
     flake8_newer()
     flake8_older()
+
+def test_remove_stale_cache_values(tmpdir):
+    """Tests that we remove stale (older than a week) cached packages
+    and wheels, while still keeping everything created within the past week.
+    """
+    import os
+    import time
+
+    tmpdir.chdir()
+    home_path = str(Path('.').realpath())
+
+    pip_path = home_path + '/.pip'
+    cache_path = pip_path + '/cache'
+    wheelhouse_path = pip_path + '/wheelhouse'
+
+    stale_cached_package = cache_path + '/stale_package'
+    fresh_cached_package = cache_path + '/new_package'
+
+    stale_cached_wheel = wheelhouse_path + '/stale_wheel'
+    fresh_cached_wheel = wheelhouse_path + '/new_wheel'
+
+    # Creates a cached package and wheel in their respective
+    # .pip/cache/ and .pip/wheelhouse directories.
+    os.makedirs(stale_cached_package)
+    os.makedirs(fresh_cached_package)
+    os.makedirs(stale_cached_wheel)
+    os.makedirs(fresh_cached_wheel)
+
+    # Create some rough times for testing. These represent, in
+    # seconds since epoch, a time from today, this week, and last month
+    seconds_in_day = 86400
+    today_time = int(time.time())
+    this_week_time = int(time.time()) - seconds_in_day*3
+    last_month_time = int(time.time()) - seconds_in_day*40
+    epoch_time = 0
+
+    # Sets the access times of stale package/wheel to be older than a week.
+    os.utime(stale_cached_package, (epoch_time, epoch_time))  # Jan 1, 1970
+    os.utime(stale_cached_wheel, (last_month_time, last_month_time))
+
+    # Sets the access times of fresh package/wheel to be within the past week.
+    os.utime(fresh_cached_package, (today_time, today_time))
+    os.utime(fresh_cached_wheel, (this_week_time, this_week_time))
+
+    requirements('')
+    venv_update()
+
+    # Assert that we can no longer access the stale package/wheel
+    # because tmpwatch has removed them.
+    assert os.access(stale_cached_package, os.F_OK) == False
+    assert os.access(stale_cached_wheel, os.F_OK) == False
+
+    # Assert that we can still access the fresh package/wheel,
+    # tmpwatch should not have removed them.
+    assert os.access(fresh_cached_package, os.F_OK) == True
+    assert os.access(fresh_cached_wheel, os.F_OK) == True

--- a/tests/functional/simple_test.py
+++ b/tests/functional/simple_test.py
@@ -452,6 +452,7 @@ def test_downgrade(tmpdir):
     flake8_newer()
     flake8_older()
 
+
 def test_remove_stale_cache_values(tmpdir):
     """Tests that we remove stale (older than a week) cached packages
     and wheels, while still keeping everything created within the past week.
@@ -483,14 +484,14 @@ def test_remove_stale_cache_values(tmpdir):
     # seconds since epoch, a time from today, this week, and last month
     seconds_in_day = 86400
     today_time = int(time.time())
-    this_week_time = int(time.time()) - seconds_in_day*3
-    last_month_time = int(time.time()) - seconds_in_day*40
+    this_week_time = int(time.time()) - seconds_in_day * 3
+    last_month_time = int(time.time()) - seconds_in_day * 40
 
-    # Sets the access times of stale package/wheel to be older than a week.
+    # Set access times of stale package/wheel to be older than a week.
     os.utime(stale_cached_package, (0, 0))  # Jan 1, 1970
     os.utime(stale_cached_wheel, (last_month_time, last_month_time))
 
-    # Sets the access times of fresh package/wheel to be within the past week.
+    # Set access times of fresh package/wheel to be within the past week.
     os.utime(fresh_cached_package, (today_time, today_time))
     os.utime(fresh_cached_wheel, (this_week_time, this_week_time))
 

--- a/venv_update.py
+++ b/venv_update.py
@@ -424,6 +424,9 @@ def do_install(reqs):
         PIP_DOWNLOAD_CACHE=pip_download_cache,
     )
 
+    # Remove stale values from the cache that have not been accessed in a week.
+    run(["tmpwatch", "7d", pip_download_cache])
+
     cache_opts = (
         '--download-cache=' + pip_download_cache,
         '--find-links=file://' + pip_wheels,

--- a/venv_update.py
+++ b/venv_update.py
@@ -463,7 +463,7 @@ def do_install(reqs):
         pip(('uninstall', '--yes') + tuple(sorted(extraneous)))
 
     # Cleanup: remove stale values from the cache and wheelhouse that have not been accessed in a week.
-    run(['tmpwatch', '7d', pip_download_cache, pip_wheels])
+    run(['find', pip_download_cache, pip_wheels, '-not', '-atime', '-7', '-exec', 'rm', '-rf', '{}', '+'])
 
 
 def wait_for_all_subprocesses():

--- a/venv_update.py
+++ b/venv_update.py
@@ -462,8 +462,8 @@ def do_install(reqs):
     if extraneous:
         pip(('uninstall', '--yes') + tuple(sorted(extraneous)))
 
-    # Cleanup: remove stale values from the cache that have not been accessed in a week.
-    run(['tmpwatch', '7d', pip_download_cache])
+    # Cleanup: remove stale values from the cache and wheelhouse that have not been accessed in a week.
+    run(['tmpwatch', '7d', pip_download_cache, pip_wheels])
 
 
 def wait_for_all_subprocesses():

--- a/venv_update.py
+++ b/venv_update.py
@@ -424,9 +424,6 @@ def do_install(reqs):
         PIP_DOWNLOAD_CACHE=pip_download_cache,
     )
 
-    # Remove stale values from the cache that have not been accessed in a week.
-    run(['tmpwatch', '7d', pip_download_cache])
-
     cache_opts = (
         '--download-cache=' + pip_download_cache,
         '--find-links=file://' + pip_wheels,
@@ -464,6 +461,9 @@ def do_install(reqs):
     # 2) Uninstall any extraneous packages.
     if extraneous:
         pip(('uninstall', '--yes') + tuple(sorted(extraneous)))
+
+    # Cleanup: remove stale values from the cache that have not been accessed in a week.
+    run(['tmpwatch', '7d', pip_download_cache])
 
 
 def wait_for_all_subprocesses():

--- a/venv_update.py
+++ b/venv_update.py
@@ -425,7 +425,7 @@ def do_install(reqs):
     )
 
     # Remove stale values from the cache that have not been accessed in a week.
-    run(["tmpwatch", "7d", pip_download_cache])
+    run(['tmpwatch', '7d', pip_download_cache])
 
     cache_opts = (
         '--download-cache=' + pip_download_cache,


### PR DESCRIPTION
I have something that works--I checked my .pip/cache before and after; without this, old values stick around on running venv_update. With this, we only have values accessed in the last week.

There's a failing test that I don't understand well, tests/functional/stage2_test.py::test_trivial. It only fails with this change. Functionally as far as I can tell tmpwatch is doing no more than expected, so I'm thinking the test itself will have to change. I didn't add any tests because I wasn't sure how I'd do that, for one, and I assume tmpwatch is pretty well-tested.

Wanted to get some feedback before trying to add/change tests. :)