### PR TITLE
Fall back to unvendored pkg_resources if pip._vendor fails

### DIFF
--- a/.pep8
+++ b/.pep8
@@ -5,4 +5,4 @@ exclude=.tox,*.tmp,tmp/
 [flake8]
 max-line-length=131
 exclude=.tox,*.tmp,tmp/
-max-complexity=10
+max-complexity=12

--- a/venv_update.py
+++ b/venv_update.py
@@ -277,7 +277,11 @@ def pip_install(args):
 
 def fresh_working_set():
     """return a pkg_resources "working set", representing the *currently* installed pacakges"""
-    from pip._vendor import pkg_resources
+    try:
+        from pip._vendor import pkg_resources
+    except ImportError:  # pragma: no cover
+        # Debian de-vendorizes the version of pip it ships
+        import pkg_resources
 
     class WorkingSetPlusEditableInstalls(pkg_resources.WorkingSet):
 
@@ -298,7 +302,11 @@ def trace_requirements(requirements):
     from collections import deque
     from pip import logger
     from pip.req import InstallRequirement
-    from pip._vendor import pkg_resources
+    try:
+        from pip._vendor import pkg_resources
+    except ImportError:  # pragma: no cover
+        # Debian de-vendorizes the version of pip it ships
+        import pkg_resources
 
     working_set = fresh_working_set()
 


### PR DESCRIPTION
This would fix #65.