### PR TITLE
Changed from using find -exec to -delete. Added a try/except block so we

### DIFF
--- a/venv_update.py
+++ b/venv_update.py
@@ -469,6 +469,7 @@ def do_install(reqs):
     except CalledProcessError:  # Ignore errors due to concurrent file access race conditions.
         pass
 
+
 def wait_for_all_subprocesses():
     from os import wait
     try:

--- a/venv_update.py
+++ b/venv_update.py
@@ -463,8 +463,11 @@ def do_install(reqs):
         pip(('uninstall', '--yes') + tuple(sorted(extraneous)))
 
     # Cleanup: remove stale values from the cache and wheelhouse that have not been accessed in a week.
-    run(['find', pip_download_cache, pip_wheels, '-not', '-atime', '-7', '-exec', 'rm', '-rf', '{}', '+'])
-
+    from subprocess import CalledProcessError
+    try:
+        run(['find', pip_download_cache, pip_wheels, '-not', '-atime', '-7', '-delete'])
+    except CalledProcessError:  # Ignore errors due to concurrent file access race conditions.
+        pass
 
 def wait_for_all_subprocesses():
     from os import wait


### PR DESCRIPTION
do not fail on concurrent file access race conditions.

The try/except is a little strange, because we catch and exit as a failure on the same CalledProcessError if venv_update anywhere raises it. In this particular case, we want to ignore it--it simply means that another instance of venv_update has already touched and deleted the file we're at. I'm open to alternatives, including just directly using subprocess.call(..) here.