### PR TITLE
Use `python -m pip` instead of `pip` directly

### DIFF
--- a/venv_update.py
+++ b/venv_update.py
@@ -540,7 +540,7 @@ def stage1(venv_path, reqs):
         return 'virtualenv executable not found: %s' % python
 
     # ensure that a compatible version of pip is installed
-    run(('pip', '--version'))
+    run((python, '-m', 'pip.__main__', '--version'))
     run((python, '-m', 'pip.__main__', 'install', 'pip>=1.5.0,<6.0.0'))
 
     exec_((python, dotpy(__file__), '--stage2', venv_path) + reqs)  # never returns


### PR DESCRIPTION
After applying the patch from #67, venv_update works with Python 3 only on Debian jessie.

This fixes #66.