### PR TITLE
Fix reference to "PIP_INDEX_SERVER"

### DIFF
--- a/venv_update.py
+++ b/venv_update.py
@@ -7,8 +7,8 @@ Update a (possibly non-existant) virtualenv directory using a requirements.txt l
 When this script completes, the virtualenv should have the same packages as if it were
 removed, then rebuilt.
 
-To set the index server, export a PIP_INDEX_SERVER variable.
-    See also: http://pip.readthedocs.org/en/latest/user_guide.html#environment-variables
+To set the index server, export a PIP_INDEX_URL variable.
+    See also: https://pip.readthedocs.org/en/stable/user_guide/#environment-variables
 
 positional arguments:
   virtualenv_dir  Destination virtualenv directory (default: virtualenv_run)


### PR DESCRIPTION
I'm pretty sure `PIP_INDEX_SERVER` is not actually a thing.

Also fixes a rotted link.