### PR TITLE
Fix arg parsing in pip_faster with custom requirements files

### DIFF
--- a/pip_faster.py
+++ b/pip_faster.py
@@ -361,7 +361,9 @@ def main():
     from sys import argv, path
     del path[:1]  # we don't (want to) import anything from pwd or the script's directory
     # TODO(Yelp/#58): Don't use venv-update's parseargs, instead conform to pip's args
-    _, _, reqs, _ = parseargs(argv[1:])
+    # We pass a fake virtualenv path as the first argument to parseargs since
+    # we don't need (or know) the actual path, but parseargs will expect it.
+    _, _, reqs, _ = parseargs(['fake_venv_path'] + argv[1:])
 
     try:
         return do_install(reqs)

--- a/tests/functional/simple_test.py
+++ b/tests/functional/simple_test.py
@@ -150,6 +150,22 @@ def test_cached_clean_install_faster(tmpdir):
     assert 1.75 < install_twice(tmpdir, between=clean) < 7
 
 
+def test_install_custom_path_and_requirements(tmpdir):
+    """Show that we can install to a custom directory with a custom
+    requirements file."""
+    tmpdir.chdir()
+    requirements(
+        'six==1.8.0\n',
+        path='requirements2.txt',
+    )
+    venv_update('venv', 'requirements2.txt')
+    assert pip_freeze('venv') == '\n'.join((
+        'six==1.8.0',
+        'wheel==0.24.0',
+        ''
+    ))
+
+
 def test_arguments_version(tmpdir):
     """Show that we can pass arguments through to virtualenv"""
     tmpdir.chdir()
@@ -190,8 +206,9 @@ for p in sys.path:
     assert out and Path(out).isdir()
 
 
-def pip_freeze():
-    out, err = run('./virtualenv_run/bin/pip', 'freeze', '--local')
+def pip_freeze(venv='virtualenv_run'):
+    from os.path import join
+    out, err = run(join(venv, 'bin', 'pip'), 'freeze', '--local')
 
     # Most python distributions which have argparse in the stdlib fail to
     # expose it to setuptools as an installed package (it seems all but ubuntu

--- a/tests/testing/__init__.py
+++ b/tests/testing/__init__.py
@@ -11,9 +11,9 @@ from py._path.local import LocalPath as Path
 TOP = Path(__file__) / '../../..'
 
 
-def requirements(reqs):
+def requirements(reqs, path='requirements.txt'):
     """Write a requirements.txt file to the current working directory."""
-    Path('requirements.txt').write(reqs)
+    Path(path).write(reqs)
 
 
 def run(*cmd, **env):


### PR DESCRIPTION
@matthew-mcallister reported that venv_update was gobbling the path to the requirements file that he passed on the command line.

Indeed, you can see that it initially reads the file I asked it to, but then in stage 2 complains about requirements.txt not existing:

```shell
ckuehl@supernova:~$ cd $(mktemp -d)
ckuehl@supernova:/tmp/tmp.q2KE9PsDuT$ cp ~/proj/pip-faster/{venv_update.py,pip_faster.py} .
ckuehl@supernova:/tmp/tmp.q2KE9PsDuT$ echo six > derp.txt
ckuehl@supernova:/tmp/tmp.q2KE9PsDuT$ python venv_update.py venv derp.txt
> /usr/bin/python -m virtualenv venv
Running virtualenv with interpreter /usr/bin/python2
New python executable in /tmp/tmp.q2KE9PsDuT/venv/bin/python2
Also creating executable in /tmp/tmp.q2KE9PsDuT/venv/bin/python
Installing setuptools, pip...done.
> venv/bin/python -m pip.__main__ --version
pip 1.5.6 from /tmp/tmp.q2KE9PsDuT/venv/local/lib/python2.7/site-packages (python 2.7)
> venv/bin/python -m pip.__main__ install 'pip>=1.5.0,<6.0.0'
Requirement already satisfied (use --upgrade to upgrade): pip<6.0.0,>=1.5.0 in ./venv/lib/python2.7/site-packages
Cleaning up...
> venv/bin/python venv_update.py --stage2 venv derp.txt
Traceback (most recent call last):
  File "/tmp/tmp.q2KE9PsDuT/pip_faster.py", line 377, in <module>
    exit(main())
  File "/tmp/tmp.q2KE9PsDuT/pip_faster.py", line 367, in main
    return do_install(reqs)
  File "/tmp/tmp.q2KE9PsDuT/pip_faster.py", line 296, in do_install
    required = pip_parse_requirements(reqs)
  File "/tmp/tmp.q2KE9PsDuT/pip_faster.py", line 162, in pip_parse_requirements
    for req in parse_requirements(reqfile):
  File "/tmp/tmp.q2KE9PsDuT/venv/local/lib/python2.7/site-packages/pip/req.py", line 1547, in parse_requirements
    session=session,
  File "/tmp/tmp.q2KE9PsDuT/venv/local/lib/python2.7/site-packages/pip/download.py", line 278, in get_file_content
    raise InstallationError('Could not open requirements file: %s' % str(e))
pip.exceptions.InstallationError: Could not open requirements file: [Errno 2] No such file or directory: u'requirements.txt'

Something went wrong! Sending 'venv' back in time, so make knows it's invalid.
Waiting for all subprocesses to finish...
DONE
> touch venv --reference derp.txt --date '1 day ago'
```