### PR TITLE
Work with older setuptools by requiring new setuptools inside venv

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ def main():
         install_requires=[
             'virtualenv>=1.11.5,<2.0',  # just for venv-update
             'pip>=1.5.0,<6.0.0',
+            'setuptools>=0.8.0',
             'wheel>0.25.0',  # 0.25.0 causes get_tag AssertionError in python3
         ],
         entry_points={


### PR DESCRIPTION
This fixes #33 by ensuring that we have a newer setuptools inside our target virtualenv.

Stupidly simple fix, but the regression test fails before and succeeds afterwards.