### PR TITLE
Fix broken symlinks or missing Python in scratch virtualenv

### DIFF
--- a/tests/regression/venv_update.py
+++ b/tests/regression/venv_update.py
@@ -1,0 +1,40 @@
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import pytest
+
+from testing import enable_coverage
+from testing import pip_freeze
+from testing import requirements
+from testing import venv_update
+from venv_update import __version__
+
+
+@pytest.mark.usefixtures('pypi_server')
+def test_bad_symlink_can_be_fixed(tmpdir):
+    """If the symlink at ~/.config/venv-update/$version/venv-update is wrong,
+    we should be able to fix it and keep going."""
+    tmpdir.chdir()
+
+    scratch_dir = tmpdir.join('home', '.cache').ensure_dir('venv-update').ensure_dir(__version__)
+    symlink = scratch_dir.join('venv-update')
+
+    # run a trivial venv-update to populate the cache and create a proper symlink
+    assert not symlink.exists()
+    requirements('')
+    venv_update()
+    assert symlink.exists()
+
+    # break the symlink by hand (in real life, this can happen if mounting
+    # things into Docker containers, for example)
+    symlink.remove()
+    symlink.mksymlinkto('/nonexist')
+    assert not symlink.exists()
+
+    # a simple venv-update should install packages and fix the symlink
+    enable_coverage(tmpdir)
+    requirements('pure-python-package')
+    venv_update()
+    assert '\npure-python-package==0.2.0\n' in pip_freeze()
+    assert symlink.exists()


### PR DESCRIPTION
This fixes #98 

If you do something like mount part of `~/.cache` into a Docker container, you might end up with a symlink pointing somewhere that doesn't exist, and we'll never be able to fix it.