### PR TITLE
Don't `make venv` in .activate.sh

### DIFF
--- a/.activate.sh
+++ b/.activate.sh
@@ -1,3 +1,2 @@
 export TOP=$PWD
-make venv
 . venv/bin/activate


### PR DESCRIPTION
@bukzor @kentwills thoughts?

* Making a virtualenv when you cd into a directory is totally unexpected
* It takes a long time and is difficult to stop (^C works but then it keeps trying to rebuild it every time you do something)
* If venv_update happens to be broken in your branch, it might fail and then keep trying.
* It's annoying enough that I disabled aactivator for this repo